### PR TITLE
Fix #5 – Déplacer les identifiants API dans App.config

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -2,9 +2,12 @@
 <configuration>
     <configSections>
     </configSections>
-    <startup> 
+    <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+  <appSettings>
+    <add key="api.credentials" value="admin:adminpwd" />
+  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -53,7 +53,7 @@ namespace MediaTekDocuments.dal
             String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
+                authenticationString = ConfigurationManager.AppSettings["api.credentials"];
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)


### PR DESCRIPTION
Les identifiants "admin:adminpwd" étaient écrits en dur dans Access.cs.
Ils sont maintenant stockés dans App.config sous la clé api.credentials
et lus via ConfigurationManager.AppSettings.